### PR TITLE
Bugfix - random choice didn't choose from the full array

### DIFF
--- a/state/scrambler.js
+++ b/state/scrambler.js
@@ -76,11 +76,15 @@ let subGroup = {
 };
 
 function auf() {
-    return ['','U','U\'','U2'][(Math.random()*3)|0];
+    return randFromArray(['','U','U\'','U2']);
 }
 
 function m2() {
-    return ['','M2'][(Math.random()*2)|0];
+    return randFromArray(['','M2']);
+}
+
+function randFromArray(options) {
+    return options[(Math.random()*options.length)|0];
 }
 
 function setSolved(cube) {


### PR DESCRIPTION
An off by one error meant you could never get 'U2' from auf. This fix introduces a function to pick randomly from the array. If this isn't the best place for the function feel free to move it to somewhere more suitable